### PR TITLE
Implement dialogue orchestrator with skills and memory

### DIFF
--- a/config/skill_matrix.yaml
+++ b/config/skill_matrix.yaml
@@ -1,0 +1,25 @@
+{
+  "default_skill": "empathy",
+  "priorities": {
+    "empathy": 2.0,
+    "logic": 1.5
+  },
+  "transition_weights": {
+    "empathy": {
+      "empathy": 0.7,
+      "logic": 0.5
+    },
+    "logic": {
+      "logic": 0.8,
+      "empathy": 0.6
+    }
+  },
+  "conflict_resolution": {
+    "empathy": {
+      "overrides": ["logic"]
+    },
+    "logic": {
+      "overrides": []
+    }
+  }
+}

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,18 @@
+"""Core modules for the dialogue assistant."""
+from core.orchestrator import DialogueOrchestrator
+from core.memory import (
+    MemoryManager,
+    MemoryRecord,
+    ShortTermMemory,
+    BaseLongTermMemory,
+    SQLiteLongTermMemory,
+)
+
+__all__ = [
+    "DialogueOrchestrator",
+    "MemoryManager",
+    "MemoryRecord",
+    "ShortTermMemory",
+    "BaseLongTermMemory",
+    "SQLiteLongTermMemory",
+]

--- a/core/memory.py
+++ b/core/memory.py
@@ -1,0 +1,192 @@
+"""Utility classes for managing conversational memory.
+
+This module contains implementations for short-term memory that keeps track of
+recent dialogue turns and optional long-term memory backends.  The
+``MemoryManager`` orchestrates the interaction between these memories and is
+used by the dialogue orchestrator.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+import json
+import sqlite3
+
+
+@dataclass
+class MemoryRecord:
+    """Represents a single conversational message."""
+
+    role: str
+    content: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the record."""
+        return {
+            "role": self.role,
+            "content": self.content,
+            "timestamp": self.timestamp.isoformat(),
+            "metadata": self.metadata,
+        }
+
+
+class ShortTermMemory:
+    """Keeps track of the latest dialogue turns in chronological order."""
+
+    def __init__(self, max_length: int = 20) -> None:
+        self.max_length = max_length
+        self._messages: List[MemoryRecord] = []
+
+    def add_message(self, record: MemoryRecord) -> None:
+        """Add a message to the short-term buffer and trim the overflow."""
+        self._messages.append(record)
+        if len(self._messages) > self.max_length:
+            overflow = len(self._messages) - self.max_length
+            del self._messages[0:overflow]
+
+    def get_recent(self, limit: Optional[int] = None) -> List[MemoryRecord]:
+        """Return the most recent ``limit`` messages (all if ``None``)."""
+        if limit is None or limit >= len(self._messages):
+            return list(self._messages)
+        return self._messages[-limit:]
+
+    def clear(self) -> None:
+        """Remove all stored messages."""
+        self._messages.clear()
+
+    def __iter__(self) -> Iterable[MemoryRecord]:
+        return iter(self._messages)
+
+
+class BaseLongTermMemory(ABC):
+    """Abstract interface for pluggable long-term memory backends."""
+
+    @abstractmethod
+    def store_interaction(self, record: MemoryRecord) -> None:
+        """Persist an interaction for later retrieval."""
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 5) -> List[MemoryRecord]:
+        """Return a list of relevant interactions based on ``query``."""
+
+
+class SQLiteLongTermMemory(BaseLongTermMemory):
+    """SQLite-based implementation of :class:`BaseLongTermMemory`.
+
+    The database schema is intentionally simple and keeps the full JSON
+    representation of the metadata column.  The class is small enough to be
+    replaced with a vector store or a more advanced backend without changing
+    the consumer interface.
+    """
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = Path(db_path)
+        self._connection = sqlite3.connect(self.db_path)
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        cursor = self._connection.cursor()
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                metadata TEXT,
+                timestamp TEXT NOT NULL
+            )
+            """
+        )
+        self._connection.commit()
+
+    def store_interaction(self, record: MemoryRecord) -> None:
+        cursor = self._connection.cursor()
+        cursor.execute(
+            """
+            INSERT INTO interactions (role, content, metadata, timestamp)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                record.role,
+                record.content,
+                json.dumps(record.metadata, ensure_ascii=False),
+                record.timestamp.isoformat(),
+            ),
+        )
+        self._connection.commit()
+
+    def search(self, query: str, limit: int = 5) -> List[MemoryRecord]:
+        cursor = self._connection.cursor()
+        cursor.execute(
+            """
+            SELECT role, content, metadata, timestamp
+            FROM interactions
+            WHERE content LIKE ?
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (f"%{query}%", limit),
+        )
+        rows = cursor.fetchall()
+        results: List[MemoryRecord] = []
+        for role, content, metadata, timestamp in rows:
+            metadata_dict = json.loads(metadata) if metadata else {}
+            results.append(
+                MemoryRecord(
+                    role=role,
+                    content=content,
+                    metadata=metadata_dict,
+                    timestamp=datetime.fromisoformat(timestamp),
+                )
+            )
+        return results
+
+    def close(self) -> None:
+        self._connection.close()
+
+
+class MemoryManager:
+    """Aggregates short-term and optional long-term memories."""
+
+    def __init__(
+        self,
+        short_term: Optional[ShortTermMemory] = None,
+        long_term: Optional[BaseLongTermMemory] = None,
+    ) -> None:
+        self.short_term = short_term or ShortTermMemory()
+        self.long_term = long_term
+
+    def add_message(
+        self,
+        role: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        persist_long_term: bool = False,
+    ) -> MemoryRecord:
+        """Add a message to the short-term buffer and optionally persist it."""
+        record = MemoryRecord(role=role, content=content, metadata=metadata or {})
+        self.short_term.add_message(record)
+        if persist_long_term and self.long_term is not None:
+            self.long_term.store_interaction(record)
+        return record
+
+    def get_recent(self, limit: Optional[int] = None) -> List[MemoryRecord]:
+        return self.short_term.get_recent(limit)
+
+    def search_long_term(self, query: str, limit: int = 5) -> List[MemoryRecord]:
+        if self.long_term is None:
+            return []
+        return self.long_term.search(query, limit)
+
+    def clear(self) -> None:
+        self.short_term.clear()
+
+    def close(self) -> None:
+        if hasattr(self.long_term, "close"):
+            self.long_term.close()  # type: ignore[attr-defined]

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,0 +1,263 @@
+"""Dialogue orchestrator that coordinates skills and memory."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+import json
+import logging
+
+from core.memory import MemoryManager, MemoryRecord
+from services.openai_client import OpenAIClient
+
+try:  # Optional dependency for YAML.
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover - fallback when PyYAML is unavailable.
+    yaml = None
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SkillDecision:
+    """Represents the decision process for a single assistant turn."""
+
+    skill_name: str
+    scores: Dict[str, float]
+    prompt: str
+
+
+class DialogueOrchestrator:
+    """Route user input to the best suited skill while tracking context."""
+
+    def __init__(
+        self,
+        memory: Optional[MemoryManager] = None,
+        openai_client: Optional[OpenAIClient] = None,
+        skill_registry: Optional[Mapping[str, Any]] = None,
+        skill_config_dir: Optional[Path] = None,
+        skill_matrix_path: Optional[Path] = None,
+        history_limit: int = 6,
+    ) -> None:
+        from skills import SKILL_REGISTRY  # Imported lazily to avoid cycles.
+
+        self.memory = memory or MemoryManager()
+        self.openai_client = openai_client or OpenAIClient()
+        self.history_limit = history_limit
+        self.skill_config_dir = Path(skill_config_dir or Path("skills") / "config")
+        self.skill_matrix_path = Path(skill_matrix_path or Path("config") / "skill_matrix.yaml")
+        self.skill_configs = self._load_skill_configs(self.skill_config_dir)
+        registry = dict(skill_registry or SKILL_REGISTRY)
+        self.skill_matrix = self._load_skill_matrix(self.skill_matrix_path)
+        self.skills = self._instantiate_skills(registry)
+        self._turn_history: List[str] = []
+        self._awaiting_user_input = True
+        self._last_decision: Optional[SkillDecision] = None
+
+    # ------------------------------------------------------------------
+    # Loading helpers
+    def _load_skill_configs(self, directory: Path) -> Dict[str, Dict[str, Any]]:
+        configs: Dict[str, Dict[str, Any]] = {}
+        if not directory.exists():
+            LOGGER.warning("Skill configuration directory %s does not exist", directory)
+            return configs
+
+        for path in directory.iterdir():
+            if path.suffix.lower() not in {".yaml", ".yml", ".json"}:
+                continue
+            try:
+                configs[path.stem] = self._load_structured_file(path)
+            except Exception as exc:  # pragma: no cover - logging side effect
+                LOGGER.exception("Failed to load skill configuration %s: %s", path, exc)
+        return configs
+
+    def _load_skill_matrix(self, path: Path) -> Dict[str, Any]:
+        if path.exists():
+            try:
+                return self._load_structured_file(path)
+            except Exception as exc:  # pragma: no cover - logging side effect
+                LOGGER.exception("Failed to load skill matrix %s: %s", path, exc)
+        return {
+            "default_skill": next(iter(self.skill_configs), ""),
+            "priorities": {},
+            "transition_weights": {},
+            "conflict_resolution": {},
+        }
+
+    def _load_structured_file(self, path: Path) -> Dict[str, Any]:
+        text = path.read_text(encoding="utf-8")
+        if path.suffix.lower() == ".json":
+            return json.loads(text)
+        if yaml is not None:
+            return yaml.safe_load(text)
+        # YAML is a superset of JSON, so fall back to JSON parsing.
+        return json.loads(text)
+
+    def _instantiate_skills(self, registry: Mapping[str, Any]) -> Dict[str, Any]:
+        instances: Dict[str, Any] = {}
+        for name, cls in registry.items():
+            config = self.skill_configs.get(name, {"name": name})
+            instances[name] = cls(config=config, openai_client=self.openai_client)
+        return instances
+
+    # ------------------------------------------------------------------
+    # Public API
+    def process_user_input(self, user_input: str) -> Dict[str, Any]:
+        """Process a user utterance and return the generated assistant reply."""
+        user_input = user_input.strip()
+        if not user_input:
+            raise ValueError("User input must not be empty")
+
+        if not self._awaiting_user_input:
+            LOGGER.info("Received user input while assistant turn was pending; resetting state.")
+        self._awaiting_user_input = False
+
+        persist_long_term = getattr(self.memory, "long_term", None) is not None
+        user_record = self.memory.add_message("user", user_input, persist_long_term=persist_long_term)
+        context = self._build_context(user_record)
+        scores = self._score_skills(user_input)
+        skill_name = self._resolve_conflicts(scores)
+
+        skill = self.skills[skill_name]
+        guidance = self._build_orchestrator_prompt(context, scores)
+        prompt = self.openai_client.format_skill_prompt(
+            skill_name=skill_name,
+            persona=self.skill_configs.get(skill_name, {}).get("persona", skill_name),
+            style=self.skill_configs.get(skill_name, {}).get("style", ""),
+            recent_dialogue=self._format_messages(context["recent_messages"]),
+            user_input=user_input,
+            guidance=guidance,
+        )
+        response = skill.generate_response(
+            {
+                **context,
+                "orchestrator_prompt": guidance,
+                "skill_prompt": prompt,
+                "skill_scores": scores,
+            }
+        )
+
+        assistant_metadata = {"skill": skill_name, "scores": scores}
+        assistant_record = self.memory.add_message(
+            "assistant", response, metadata=assistant_metadata, persist_long_term=persist_long_term
+        )
+        self._turn_history.append(skill_name)
+        self._awaiting_user_input = True
+
+        decision = SkillDecision(skill_name=skill_name, scores=scores, prompt=prompt)
+        self._last_decision = decision
+
+        return {
+            "response": response,
+            "skill": skill_name,
+            "decision": decision,
+            "records": {
+                "user": user_record.to_dict(),
+                "assistant": assistant_record.to_dict(),
+            },
+        }
+
+    def reset(self) -> None:
+        """Clear internal state and memory."""
+        self.memory.clear()
+        self._turn_history.clear()
+        self._awaiting_user_input = True
+        self._last_decision = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _build_context(self, user_record: MemoryRecord) -> Dict[str, Any]:
+        recent_messages = self.memory.get_recent(self.history_limit)
+        long_term = self.memory.search_long_term(user_record.content, limit=3)
+        return {
+            "recent_messages": recent_messages,
+            "long_term_memories": long_term,
+            "user_input": user_record.content,
+            "turn_history": list(self._turn_history),
+            "last_skill": self._turn_history[-1] if self._turn_history else None,
+        }
+
+    def _format_messages(self, messages: Iterable[MemoryRecord]) -> str:
+        lines = []
+        for record in messages:
+            meta = record.metadata.get("skill") if record.metadata else None
+            skill_note = f" ({meta})" if meta else ""
+            lines.append(f"{record.timestamp.isoformat()} - {record.role}{skill_note}: {record.content}")
+        return "\n".join(lines)
+
+    def _score_skills(self, user_input: str) -> Dict[str, float]:
+        scores: Dict[str, float] = {}
+        lower_input = user_input.lower()
+        last_skill = self._turn_history[-1] if self._turn_history else None
+        transitions: Dict[str, Dict[str, float]] = self.skill_matrix.get("transition_weights", {})
+        priorities: Dict[str, float] = self.skill_matrix.get("priorities", {})
+        for name, config in self.skill_configs.items():
+            base = float(config.get("base_weight", 1.0))
+            keywords = [kw.lower() for kw in config.get("keywords", [])]
+            hits = sum(1 for kw in keywords if kw in lower_input)
+            weight = base + hits
+            if last_skill:
+                weight *= transitions.get(last_skill, {}).get(name, 1.0)
+            weight *= priorities.get(name, 1.0)
+            scores[name] = weight
+        # Ensure that every known skill receives a score.
+        for name in self.skills:
+            scores.setdefault(name, 1.0)
+        return scores
+
+    def _resolve_conflicts(self, scores: Dict[str, float]) -> str:
+        if not scores:
+            raise RuntimeError("No skills registered")
+        max_score = max(scores.values())
+        candidates = [name for name, score in scores.items() if score == max_score]
+        if len(candidates) == 1:
+            return candidates[0]
+        winner = self._apply_conflict_rules(candidates)
+        if winner is not None:
+            return winner
+        default_skill = self.skill_matrix.get("default_skill")
+        if default_skill in candidates:
+            return default_skill
+        # Fallback to deterministic ordering to avoid randomness.
+        return sorted(candidates)[0]
+
+    def _apply_conflict_rules(self, candidates: List[str]) -> Optional[str]:
+        rules = self.skill_matrix.get("conflict_resolution", {})
+        priorities = self.skill_matrix.get("priorities", {})
+        # Rule-based overrides.
+        for candidate in candidates:
+            overrides = rules.get(candidate, {}).get("overrides", [])
+            if any(other in candidates for other in overrides):
+                return candidate
+        # Priority-based resolution.
+        if priorities:
+            sorted_candidates = sorted(
+                candidates, key=lambda name: priorities.get(name, 0), reverse=True
+            )
+            top = sorted_candidates[0]
+            if len(sorted_candidates) == 1:
+                return top
+            top_priority = priorities.get(top, 0)
+            second_priority = priorities.get(sorted_candidates[1], top_priority)
+            if top_priority != second_priority:
+                return top
+        return None
+
+    def _build_orchestrator_prompt(
+        self, context: Dict[str, Any], scores: Dict[str, float]
+    ) -> str:
+        descriptions = []
+        for name, config in self.skill_configs.items():
+            descriptions.append(
+                f"- {name}: {config.get('description', 'No description provided.')}"
+            )
+        long_term_lines = [f"* {record.content}" for record in context["long_term_memories"]]
+        return self.openai_client.format_orchestrator_prompt(
+            recent_dialogue=self._format_messages(context["recent_messages"]),
+            user_input=context["user_input"],
+            skill_descriptions="\n".join(descriptions),
+            last_skill=context.get("last_skill") or "None",
+            skill_scores=json.dumps(scores, ensure_ascii=False, indent=2),
+            long_term_context="\n".join(long_term_lines) if long_term_lines else "None",
+        )

--- a/services/openai_client.py
+++ b/services/openai_client.py
@@ -1,0 +1,88 @@
+"""Adapter around the OpenAI chat completion API."""
+from __future__ import annotations
+
+from typing import Any, Optional
+import logging
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OpenAIClient:
+    """Thin wrapper around the OpenAI SDK with prompt helpers."""
+
+    ORCHESTRATOR_PROMPT_TEMPLATE = (
+        "You are the dialogue orchestrator coordinating a team of specialised skills.\n"
+        "Conversation history:\n{recent_dialogue}\n\n"
+        "Latest user input: {user_input}\n"
+        "Available skills:\n{skill_descriptions}\n\n"
+        "Last responding skill: {last_skill}\n"
+        "Current scoring matrix: {skill_scores}\n\n"
+        "Relevant memories:\n{long_term_context}\n\n"
+        "Provide guidance for the next response keeping role boundaries clear."
+    )
+
+    SKILL_PROMPT_TEMPLATE = (
+        "You are acting as the \"{skill_name}\" persona.\n"
+        "Persona description: {persona}\n"
+        "Communication style: {style}\n\n"
+        "Conversation history:\n{recent_dialogue}\n\n"
+        "User input to address: {user_input}\n\n"
+        "Strategy guidance from orchestrator:\n{guidance}\n\n"
+        "Craft a response that fits the persona while respecting the guidance."
+    )
+
+    def __init__(self, api_key: Optional[str] = None, model: str = "gpt-3.5-turbo") -> None:
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self.model = model
+        self._client = self._initialise_client()
+
+    def _initialise_client(self) -> Optional[Any]:
+        try:
+            import openai  # type: ignore
+
+            openai.api_key = self.api_key
+            return openai
+        except ImportError:
+            LOGGER.info("OpenAI SDK not installed; falling back to simulated responses.")
+            return None
+
+    # ------------------------------------------------------------------
+    # Formatting helpers
+    def format_orchestrator_prompt(self, **kwargs: Any) -> str:
+        return self.ORCHESTRATOR_PROMPT_TEMPLATE.format(**kwargs)
+
+    def format_skill_prompt(self, **kwargs: Any) -> str:
+        return self.SKILL_PROMPT_TEMPLATE.format(**kwargs)
+
+    # ------------------------------------------------------------------
+    def generate(self, prompt: str, *, temperature: float = 0.7, **kwargs: Any) -> str:
+        """Return a response either via the OpenAI API or a local fallback."""
+        if self._client is None or not self.api_key:
+            return self._simulate_response(prompt)
+
+        try:
+            response = self._client.ChatCompletion.create(  # type: ignore[attr-defined]
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+                temperature=temperature,
+                **kwargs,
+            )
+        except Exception as exc:  # pragma: no cover - network failure handling
+            LOGGER.error("OpenAI request failed: %s", exc)
+            return self._simulate_response(prompt)
+
+        message = response["choices"][0]["message"]["content"].strip()
+        return message
+
+    def _simulate_response(self, prompt: str) -> str:
+        """Deterministic stub used when the OpenAI SDK is unavailable."""
+        preview = prompt.strip().splitlines()
+        preview = [line for line in preview if line]
+        summary = preview[-1] if preview else ""
+        return f"[Simulated response based on prompt: {summary[:120]}]"
+
+    # Convenience wrappers -------------------------------------------------
+    def generate_for_skill(self, skill_name: str, prompt: str, **kwargs: Any) -> str:
+        LOGGER.debug("Generating response for skill %s", skill_name)
+        return self.generate(prompt, **kwargs)

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -1,0 +1,15 @@
+"""Skill registry for the dialogue system."""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from skills.empathy import EmpathySkill
+from skills.logic import LogicSkill
+from skills.base import BaseSkill
+
+SKILL_REGISTRY: Dict[str, Type[BaseSkill]] = {
+    "empathy": EmpathySkill,
+    "logic": LogicSkill,
+}
+
+__all__ = ["SKILL_REGISTRY", "BaseSkill", "EmpathySkill", "LogicSkill"]

--- a/skills/base.py
+++ b/skills/base.py
@@ -1,0 +1,55 @@
+"""Base classes shared across skill implementations."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from services.openai_client import OpenAIClient
+
+
+class BaseSkill:
+    """Base skill implementation providing prompt helpers."""
+
+    def __init__(self, *, config: Dict[str, Any], openai_client: OpenAIClient) -> None:
+        self.config = config
+        self.openai_client = openai_client
+        self.name = config.get("name", self.__class__.__name__)
+
+    def build_prompt(self, context: Dict[str, Any], extra_guidance: str = "") -> str:
+        recent_dialogue = context.get("recent_messages_text")
+        if recent_dialogue is None:
+            from core.memory import MemoryRecord  # Local import to avoid cycle.
+
+            recent_messages = context.get("recent_messages", [])
+            lines = []
+            for record in recent_messages:
+                if isinstance(record, MemoryRecord):
+                    role = record.role
+                    content = record.content
+                elif isinstance(record, dict):
+                    role = record.get("role", "unknown")
+                    content = record.get("content", "")
+                else:
+                    role = str(record)
+                    content = ""
+                lines.append(f"{role}: {content}")
+            recent_dialogue = "\n".join(lines)
+        persona = self.config.get("persona", self.name)
+        style = self.config.get("style", "")
+        user_input = context.get("user_input", "")
+        guidance = context.get("orchestrator_prompt", "")
+        if extra_guidance:
+            guidance = f"{guidance}\nAdditional guidance: {extra_guidance}".strip()
+        return self.openai_client.format_skill_prompt(
+            skill_name=self.name,
+            persona=persona,
+            style=style,
+            recent_dialogue=recent_dialogue,
+            user_input=user_input,
+            guidance=guidance,
+        )
+
+    def generate_response(self, context: Dict[str, Any]) -> str:
+        prompt = context.get("skill_prompt")
+        if not prompt:
+            prompt = self.build_prompt(context)
+        return self.openai_client.generate_for_skill(self.name, prompt)

--- a/skills/config/empathy.yaml
+++ b/skills/config/empathy.yaml
@@ -1,0 +1,9 @@
+{
+  "name": "empathy",
+  "persona": "Compassionate Guide",
+  "description": "Offers emotional validation, gentle encouragement and focuses on the person's wellbeing.",
+  "style": "Warm, supportive and patient with reflective listening cues.",
+  "base_weight": 1.2,
+  "keywords": ["feel", "upset", "sad", "help", "support", "worried"],
+  "response_preamble": "Recognise emotions explicitly, mirror the user's perspective and encourage self-compassion."
+}

--- a/skills/config/logic.yaml
+++ b/skills/config/logic.yaml
@@ -1,0 +1,9 @@
+{
+  "name": "logic",
+  "persona": "Analytical Strategist",
+  "description": "Provides structured reasoning, breaks down complex problems and identifies actionable steps.",
+  "style": "Precise, concise and focused on verifiable arguments.",
+  "base_weight": 1.0,
+  "keywords": ["reason", "why", "analysis", "evidence", "logic", "plan", "steps", "concrete"],
+  "response_preamble": "Highlight assumptions, weigh alternatives and justify each conclusion."
+}

--- a/skills/empathy.py
+++ b/skills/empathy.py
@@ -1,0 +1,18 @@
+"""Empathetic conversation skill."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from skills.base import BaseSkill
+
+
+class EmpathySkill(BaseSkill):
+    """Skill that emphasises compassionate and supportive communication."""
+
+    def generate_response(self, context: Dict[str, Any]) -> str:
+        extra = self.config.get(
+            "response_preamble",
+            "Acknowledge the user's emotions, validate their feelings and offer supportive language.",
+        )
+        prompt = self.build_prompt(context, extra_guidance=extra)
+        return self.openai_client.generate_for_skill(self.name, prompt, temperature=0.8)

--- a/skills/logic.py
+++ b/skills/logic.py
@@ -1,0 +1,18 @@
+"""Analytical reasoning skill."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+from skills.base import BaseSkill
+
+
+class LogicSkill(BaseSkill):
+    """Skill focusing on structured, analytical reasoning."""
+
+    def generate_response(self, context: Dict[str, Any]) -> str:
+        extra = self.config.get(
+            "response_preamble",
+            "Respond with step-by-step reasoning and reference evidence from the conversation.",
+        )
+        prompt = self.build_prompt(context, extra_guidance=extra)
+        return self.openai_client.generate_for_skill(self.name, prompt, temperature=0.2)


### PR DESCRIPTION
## Summary
- implement a dialogue orchestrator that scores skills, loads configs and manages turn ordering
- add memory utilities with short-term and optional SQLite-backed long-term storage
- create modular skills with persona configs, an interaction matrix, and an OpenAI client with prompt templates

## Testing
- python -m compileall core services skills

------
https://chatgpt.com/codex/tasks/task_e_68cd3c5e6c548321b25a2ef51e889b76