### PR TITLE
Add assistant CLI, web UI, and profile configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Slack (work)
+SLACK_BOT_TOKEN=your-work-slack-bot-token
+SLACK_SIGNING_SECRET=your-work-signing-secret
+
+# Slack (home)
+HOME_SLACK_BOT_TOKEN=your-home-slack-bot-token
+HOME_SLACK_SIGNING_SECRET=your-home-slack-signing-secret
+
+# Telegram (work)
+TELEGRAM_BOT_TOKEN=your-work-telegram-bot-token
+TELEGRAM_CHAT_ID=telegram-chat-id-for-work
+
+# Telegram (home)
+HOME_TELEGRAM_BOT_TOKEN=your-home-telegram-bot-token
+HOME_TELEGRAM_CHAT_ID=telegram-chat-id-for-home

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.env.*
+!.env.example
+.DS_Store
+.pytest_cache/
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,123 @@
-# disco_el_assistant
+# Disco EL Assistant
+
+Disco EL Assistant is a lightweight environment for experimenting with a local
+skill orchestrator. Two profiles are provided: a "work" profile that mimics an
+enterprise environment and a "home" profile for personal automations. The
+project ships with both a Typer based CLI and an optional FastAPI + SPA web UI
+so you can test skills in whichever environment fits best.
+
+## Requirements
+
+- Python 3.10+
+- A virtual environment manager such as `venv`, `conda` or `pipenv`
+- (Optional) Node-free environment for the SPA – all assets are served as plain HTML/CSS/JS
+
+## Quick start
+
+Follow the same steps on both your work and home machines. Use different
+profiles to switch behaviours and integrations.
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/your-org/disco_el_assistant.git
+cd disco_el_assistant
+```
+
+### 2. Create a virtual environment and install dependencies
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+### 3. Configure environment variables
+
+Copy the template file and fill in the tokens relevant to your setup.
+
+```bash
+cp .env.example .env
+```
+
+- On the **work** machine, add corporate Slack and Telegram secrets.
+- On the **home** machine, add tokens for personal bots or leave values blank if
+  the integration is disabled in the profile.
+
+Environment variables are loaded automatically by both the CLI and the web app.
+
+### 4. Review profile configuration
+
+Profile-specific settings live in `config/work.yaml` and `config/home.yaml`. The
+files describe which integrations are active (Slack, Telegram, and the local
+knowledge base) and how often the knowledge base is refreshed.
+
+Adjust the YAML files if you want to enable or disable integrations or point the
+knowledge base at different files.
+
+### 5. Launch the CLI
+
+Interactive chat session using the orchestrator:
+
+```bash
+python -m interfaces.cli chat --profile work
+```
+
+Use `--profile home` on your personal machine. Type `exit` or `quit` to stop the session.
+
+### 6. Launch the web interface (optional)
+
+Run the FastAPI server with Uvicorn:
+
+```bash
+uvicorn interfaces.web.app:app --reload --port 8000
+```
+
+Open <http://localhost:8000> in your browser. Select the desired profile from
+the drop-down and start chatting. The web UI keeps the full skill conversation
+history visible at all times.
+
+## Security policy
+
+- **Secret management:** store API keys and tokens in the `.env` file locally and
+  never commit them to version control. In production environments prefer a
+  dedicated secret manager (Vault, AWS Secrets Manager, etc.) and inject them as
+  environment variables.
+- **Profile isolation:** each profile uses its own set of environment variable
+  names to avoid leaking work credentials into the home setup and vice versa.
+- **Logging:** the sample orchestrator logs only high-level events. If you add
+  logging or persistence, redact tokens and personal data. Avoid writing secrets
+  to stdout or shared log files.
+- **Configuration files:** YAML configurations may contain paths to local
+  knowledge bases. Restrict file permissions so that only trusted users can
+  modify them.
+
+## FAQ: extending the skill set
+
+**How do I add a new skill?**
+
+Create a new class in `core/skills.py` that implements the `respond` method and
+register it inside `Orchestrator._build_skills`. Use the profile configuration
+file to toggle the skill on and off if it depends on external services.
+
+**Can the assistant call external APIs?**
+
+Yes. Add the integration settings to the relevant profile YAML and inject the
+required clients inside your skill implementation. Respect the security policy
+when handling tokens and user data.
+
+**How do I extend the knowledge base?**
+
+Edit the YAML files in `data/` or point the configuration to your own dataset.
+Every entry supports `keywords`, a `title`, and a `response`. Re-run the CLI or
+refresh the web UI to load the new content.
+
+**How do I persist conversations?**
+
+The current orchestrator keeps history in memory. To make it persistent, extend
+`Orchestrator.handle_message` to write to a database or file system, ensuring
+that personally identifiable information is encrypted at rest.
+
+---
+
+Have fun experimenting with profiles and skills! Contributions are welcome.

--- a/config/home.yaml
+++ b/config/home.yaml
@@ -1,0 +1,20 @@
+profile: home
+integrations:
+  slack:
+    enabled: false
+    bot_token_env: HOME_SLACK_BOT_TOKEN
+    signing_secret_env: HOME_SLACK_SIGNING_SECRET
+    default_channel: "#personal-lab"
+  telegram:
+    enabled: true
+    bot_token_env: HOME_TELEGRAM_BOT_TOKEN
+    chat_id_env: HOME_TELEGRAM_CHAT_ID
+    allowed_usernames:
+      - family_helper_bot
+  knowledge_base:
+    enabled: true
+    path: data/home_kb.yaml
+    embeddings_model: all-MiniLM-L6-v2
+    refresh_interval_hours: 24
+fallback_message: >-
+  I do not know how to answer that yet in the home profile. Try rephrasing or add it to the home knowledge base.

--- a/config/work.yaml
+++ b/config/work.yaml
@@ -1,0 +1,22 @@
+profile: work
+integrations:
+  slack:
+    enabled: true
+    bot_token_env: SLACK_BOT_TOKEN
+    signing_secret_env: SLACK_SIGNING_SECRET
+    default_channel: "#eng-automation"
+    notification_template: "[{profile}] {message}"
+  telegram:
+    enabled: true
+    bot_token_env: TELEGRAM_BOT_TOKEN
+    chat_id_env: TELEGRAM_CHAT_ID
+    allowed_usernames:
+      - boss_user
+      - incident_manager
+  knowledge_base:
+    enabled: true
+    path: data/work_kb.yaml
+    embeddings_model: all-MiniLM-L6-v2
+    refresh_interval_hours: 6
+fallback_message: >-
+  I'm not sure yet. Please create a ticket so that we can add this capability to the work profile.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,12 @@
+"""Core components for the Disco EL assistant."""
+from .orchestrator import Orchestrator, load_profile_config
+from .skills import FallbackSkill, KnowledgeBaseSkill, SmallTalkSkill, SkillResponse
+
+__all__ = [
+    "Orchestrator",
+    "load_profile_config",
+    "FallbackSkill",
+    "KnowledgeBaseSkill",
+    "SmallTalkSkill",
+    "SkillResponse",
+]

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,0 +1,116 @@
+"""Conversation orchestrator used by the CLI and the web interfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+from dotenv import load_dotenv
+
+from .skills import FallbackSkill, KnowledgeBaseSkill, SkillResponse, SmallTalkSkill
+
+load_dotenv()
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_DIR = PROJECT_ROOT / "config"
+
+
+@dataclass
+class ConversationTurn:
+    """Represents a single conversation turn."""
+
+    user: str
+    responses: List[SkillResponse] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "user": self.user,
+            "responses": [response.to_dict() for response in self.responses],
+        }
+
+
+def load_profile_config(profile: str) -> Dict:
+    """Load a profile configuration from the config directory."""
+
+    config_path = CONFIG_DIR / f"{profile}.yaml"
+    if not config_path.exists():
+        available = ", ".join(p.stem for p in CONFIG_DIR.glob("*.yaml"))
+        raise FileNotFoundError(
+            f"Profile '{profile}' is not available. Existing profiles: {available}"
+        )
+    with config_path.open(encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return data
+
+
+def _load_yaml(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+class Orchestrator:
+    """Simple rule-based orchestrator that routes requests to configured skills."""
+
+    def __init__(self, profile: str, config: Dict) -> None:
+        self.profile = profile
+        self.config = config
+        self.history: List[ConversationTurn] = []
+        self.fallback = FallbackSkill(
+            message=config.get("fallback_message", "I'm still learning how to respond to that.")
+        )
+        self.skills = self._build_skills(config)
+
+    @classmethod
+    def from_profile(cls, profile: str) -> "Orchestrator":
+        config = load_profile_config(profile)
+        return cls(profile=profile, config=config)
+
+    def _build_skills(self, config: Dict) -> List:
+        skills: List = [SmallTalkSkill()]
+        knowledge_entries = self._load_knowledge_base(config)
+        if knowledge_entries:
+            skills.append(KnowledgeBaseSkill(entries=knowledge_entries))
+        return skills
+
+    def _load_knowledge_base(self, config: Dict) -> List[dict]:
+        integrations = config.get("integrations", {})
+        knowledge_cfg = integrations.get("knowledge_base", {})
+        if not knowledge_cfg.get("enabled", True):
+            return []
+        entries: List[dict] = []
+        entries.extend(knowledge_cfg.get("entries", []))
+        path_value = knowledge_cfg.get("path")
+        if path_value:
+            kb_path = (PROJECT_ROOT / path_value).resolve()
+            data = _load_yaml(kb_path)
+            if isinstance(data, dict):
+                entries.extend(data.get("entries", []))
+            elif isinstance(data, list):
+                entries.extend(data)
+        return entries
+
+    def handle_message(self, message: str) -> List[SkillResponse]:
+        """Dispatch a message to all skills and update the history."""
+
+        context = {"history": [turn.to_dict() for turn in self.history], "config": self.config}
+        responses: List[SkillResponse] = []
+        for skill in self.skills:
+            result = skill.respond(message, context)
+            if result:
+                responses.append(result)
+        if not responses:
+            responses.append(self.fallback.respond(message, context))
+        turn = ConversationTurn(user=message, responses=responses)
+        self.history.append(turn)
+        return responses
+
+    def get_history(self) -> List[dict]:
+        """Return a serialisable representation of the conversation history."""
+
+        return [turn.to_dict() for turn in self.history]
+
+
+__all__ = ["Orchestrator", "load_profile_config"]

--- a/core/skills.py
+++ b/core/skills.py
@@ -1,0 +1,80 @@
+"""Skill definitions for the Disco EL assistant orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class SkillResponse:
+    """Represents a single response produced by a skill."""
+
+    skill: str
+    content: str
+
+    def to_dict(self) -> dict:
+        return {"skill": self.skill, "content": self.content}
+
+
+class Skill:
+    """Protocol-like base class for simple rule based skills."""
+
+    name: str
+
+    def respond(self, message: str, context: dict) -> Optional[SkillResponse]:
+        raise NotImplementedError
+
+
+class SmallTalkSkill(Skill):
+    """Minimal small-talk skill used for greetings and chitchat."""
+
+    name = "small_talk"
+
+    def __init__(self, greetings: Optional[Iterable[str]] = None) -> None:
+        self.greetings = [g.lower() for g in (greetings or ("hi", "hello", "hey"))]
+
+    def respond(self, message: str, context: dict) -> Optional[SkillResponse]:
+        lowered = message.lower()
+        if any(greeting in lowered for greeting in self.greetings):
+            reply = "Hello! How can I help you today?"
+            return SkillResponse(skill=self.name, content=reply)
+        if "thank" in lowered:
+            return SkillResponse(skill=self.name, content="You're welcome!")
+        return None
+
+
+class KnowledgeBaseSkill(Skill):
+    """Skill that answers based on a keyword search in a local knowledge base."""
+
+    name = "knowledge_base"
+
+    def __init__(self, entries: Optional[List[dict]] = None) -> None:
+        self.entries = entries or []
+
+    def respond(self, message: str, context: dict) -> Optional[SkillResponse]:
+        if not self.entries:
+            return None
+        lowered = message.lower()
+        for entry in self.entries:
+            keywords = [kw.lower() for kw in entry.get("keywords", [])]
+            if any(keyword in lowered for keyword in keywords):
+                response = entry.get("response") or entry.get("answer")
+                if response:
+                    response = response.strip()
+                    title = entry.get("title")
+                    if title:
+                        response = f"{title}: {response}"
+                    return SkillResponse(skill=self.name, content=response)
+        return None
+
+
+class FallbackSkill(Skill):
+    """Default skill that is triggered when nothing else matches."""
+
+    name = "fallback"
+
+    def __init__(self, message: str = "I am not sure how to help with that yet.") -> None:
+        self.message = message
+
+    def respond(self, message: str, context: dict) -> Optional[SkillResponse]:
+        return SkillResponse(skill=self.name, content=self.message)

--- a/data/home_kb.yaml
+++ b/data/home_kb.yaml
@@ -1,0 +1,19 @@
+- title: Weekly groceries
+  keywords:
+    - groceries
+    - shopping list
+    - supermarket
+  response: |
+    Check the shared Note for the latest shopping list. Order via the delivery app on Thursday evening.
+- title: Home automation reset
+  keywords:
+    - reboot hub
+    - smart home
+  response: |
+    Power cycle the smart hub in the living room and wait 3 minutes before re-enabling automations.
+- title: Family calendar sync
+  keywords:
+    - calendar
+    - schedule
+  response: |
+    Use the `/sync_calendar` command in Telegram to pull events from Google Calendar every morning at 7am.

--- a/data/work_kb.yaml
+++ b/data/work_kb.yaml
@@ -1,0 +1,23 @@
+- title: Deployment checklist
+  keywords:
+    - deploy
+    - release
+    - rollout
+  response: |
+    1. Merge the feature branch into `main`.
+    2. Run the CI/CD pipeline and confirm it passes.
+    3. Notify the #eng-automation Slack channel before promoting to production.
+    4. Use `make deploy-production` and monitor metrics for 15 minutes.
+- title: Incident escalation
+  keywords:
+    - incident
+    - outage
+    - pager
+  response: |
+    Follow the incident playbook: create a ticket, page the on-call engineer, and update the Slack incident channel every 10 minutes.
+- title: Knowledge base refresh
+  keywords:
+    - knowledge base
+    - documentation
+  response: |
+    Run `python tools/ingest_kb.py --profile work` to ingest new documents from the wiki every 6 hours.

--- a/interfaces/__init__.py
+++ b/interfaces/__init__.py
@@ -1,0 +1,1 @@
+"""Interface layers (CLI and web) for the Disco EL assistant."""

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for the Disco EL assistant."""
+from __future__ import annotations
+
+from enum import Enum
+
+import typer
+
+from core.orchestrator import Orchestrator
+
+app = typer.Typer(help="Interact with the Disco EL assistant orchestrator.")
+
+
+class ProfileOption(str, Enum):
+    WORK = "work"
+    HOME = "home"
+
+
+def _build_orchestrator(profile: ProfileOption) -> Orchestrator:
+    try:
+        return Orchestrator.from_profile(profile.value)
+    except FileNotFoundError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+
+@app.command()
+def chat(
+    profile: ProfileOption = typer.Option(
+        ProfileOption.WORK,
+        "--profile",
+        "-p",
+        case_sensitive=False,
+        help="Which profile configuration to use (work or home).",
+    ),
+) -> None:
+    """Start an interactive chat session with the orchestrator."""
+
+    orchestrator = _build_orchestrator(profile)
+    typer.secho(f"Loaded '{profile.value}' profile. Type 'exit' to quit.", fg=typer.colors.GREEN)
+
+    integrations = orchestrator.config.get("integrations", {})
+    if integrations:
+        typer.secho("Active integrations:", fg=typer.colors.BLUE)
+        for name, settings in integrations.items():
+            enabled = settings.get("enabled", True)
+            status_color = typer.colors.GREEN if enabled else typer.colors.YELLOW
+            typer.secho(f"  - {name}: {'enabled' if enabled else 'disabled'}", fg=status_color)
+
+    while True:
+        try:
+            message = typer.prompt("You")
+        except typer.Abort:
+            typer.echo("\nSession aborted.")
+            raise typer.Exit(code=0)
+        if message.strip().lower() in {"exit", "quit"}:
+            typer.secho("Goodbye!", fg=typer.colors.GREEN)
+            break
+        responses = orchestrator.handle_message(message)
+        for response in responses:
+            typer.secho(f"[{response.skill}] {response.content}", fg=typer.colors.CYAN)
+
+
+if __name__ == "__main__":
+    app()

--- a/interfaces/web/__init__.py
+++ b/interfaces/web/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI application exposing the Disco EL assistant."""

--- a/interfaces/web/app.py
+++ b/interfaces/web/app.py
@@ -1,0 +1,77 @@
+"""FastAPI application that exposes the Disco EL assistant."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+
+from core.orchestrator import Orchestrator
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+app = FastAPI(title="Disco EL Assistant", version="0.1.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+if STATIC_DIR.exists():
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+class ChatRequest(BaseModel):
+    message: str
+    profile: str = "work"
+
+
+orchestrators: Dict[str, Orchestrator] = {}
+
+
+def get_orchestrator(profile: str) -> Orchestrator:
+    profile = profile.lower()
+    if profile not in orchestrators:
+        try:
+            orchestrators[profile] = Orchestrator.from_profile(profile)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return orchestrators[profile]
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index() -> HTMLResponse:
+    if not STATIC_DIR.exists():
+        raise HTTPException(status_code=404, detail="Web UI is not available.")
+    index_path = STATIC_DIR / "index.html"
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="index.html is missing.")
+    return HTMLResponse(index_path.read_text(encoding="utf-8"))
+
+
+@app.get("/healthz")
+async def healthcheck() -> dict:
+    return {"status": "ok"}
+
+
+@app.post("/api/chat")
+async def chat(request: ChatRequest) -> dict:
+    orchestrator = get_orchestrator(request.profile)
+    responses = orchestrator.handle_message(request.message)
+    return {
+        "profile": request.profile,
+        "responses": [response.to_dict() for response in responses],
+        "history": orchestrator.get_history(),
+    }
+
+
+@app.get("/api/history")
+async def history(profile: str = "work") -> dict:
+    orchestrator = get_orchestrator(profile)
+    return {"profile": profile, "history": orchestrator.get_history()}

--- a/interfaces/web/static/index.html
+++ b/interfaces/web/static/index.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Disco EL Assistant</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        background-color: #f8f9fb;
+        color: #1f2933;
+      }
+      body {
+        margin: 0;
+        display: flex;
+        justify-content: center;
+        padding: 2rem;
+      }
+      .container {
+        width: min(960px, 100%);
+        background: white;
+        border-radius: 12px;
+        box-shadow: 0 6px 24px rgba(15, 23, 42, 0.15);
+        padding: 2rem;
+      }
+      h1 {
+        margin-top: 0;
+      }
+      #history {
+        border: 1px solid #d2d6dc;
+        border-radius: 8px;
+        padding: 1rem;
+        height: 320px;
+        overflow-y: auto;
+        background-color: #fdfdfd;
+        margin-bottom: 1.5rem;
+      }
+      .turn {
+        margin-bottom: 1rem;
+      }
+      .turn:last-child {
+        margin-bottom: 0;
+      }
+      .user {
+        font-weight: 600;
+      }
+      .skill {
+        margin-left: 1rem;
+        padding: 0.35rem 0.6rem;
+        background: #eff6ff;
+        border-radius: 6px;
+        margin-top: 0.35rem;
+      }
+      form {
+        display: flex;
+        gap: 0.5rem;
+      }
+      input[type="text"] {
+        flex: 1;
+        padding: 0.75rem;
+        border-radius: 8px;
+        border: 1px solid #cbd2d9;
+        font-size: 1rem;
+      }
+      button, select {
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        border: none;
+        background-color: #2563eb;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      select {
+        background-color: #fff;
+        color: #111827;
+        border: 1px solid #cbd2d9;
+      }
+      button:hover {
+        background-color: #1d4ed8;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Disco EL Assistant</h1>
+      <p>Select the profile and chat with the orchestrator. Type your message and press Enter.</p>
+      <div id="history"></div>
+      <form id="chat-form">
+        <select id="profile">
+          <option value="work">Work</option>
+          <option value="home">Home</option>
+        </select>
+        <input id="message" type="text" placeholder="Ask something..." required />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+    <script>
+      const form = document.getElementById("chat-form");
+      const historyContainer = document.getElementById("history");
+
+      const renderHistory = (history) => {
+        historyContainer.innerHTML = "";
+        history.forEach((turn) => {
+          const turnEl = document.createElement("div");
+          turnEl.className = "turn";
+
+          const userEl = document.createElement("div");
+          userEl.className = "user";
+          userEl.textContent = `You: ${turn.user}`;
+          turnEl.appendChild(userEl);
+
+          turn.responses.forEach((response) => {
+            const responseEl = document.createElement("div");
+            responseEl.className = "skill";
+            responseEl.textContent = `${response.skill}: ${response.content}`;
+            turnEl.appendChild(responseEl);
+          });
+
+          historyContainer.appendChild(turnEl);
+        });
+        historyContainer.scrollTop = historyContainer.scrollHeight;
+      };
+
+      const fetchHistory = async (profile) => {
+        const res = await fetch(`/api/history?profile=${encodeURIComponent(profile)}`);
+        if (res.ok) {
+          const data = await res.json();
+          renderHistory(data.history || []);
+        }
+      };
+
+      form.addEventListener("submit", async (event) => {
+        event.preventDefault();
+        const messageInput = document.getElementById("message");
+        const profileInput = document.getElementById("profile");
+        const message = messageInput.value.trim();
+        const profile = profileInput.value;
+        if (!message) {
+          return;
+        }
+        const response = await fetch("/api/chat", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ message, profile }),
+        });
+        if (response.ok) {
+          const data = await response.json();
+          renderHistory(data.history || []);
+          messageInput.value = "";
+          messageInput.focus();
+        } else {
+          alert("Failed to send message");
+        }
+      });
+
+      document.getElementById("profile").addEventListener("change", (event) => {
+        fetchHistory(event.target.value);
+      });
+
+      fetchHistory(document.getElementById("profile").value);
+    </script>
+  </body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi>=0.110.0
+uvicorn>=0.27.0
+python-dotenv>=1.0.0
+pyyaml>=6.0
+typer>=0.9.0
+rich>=13.0


### PR DESCRIPTION
## Summary
- implement a Typer-based CLI command for chatting with the orchestrator and selecting work or home profiles
- add a FastAPI service with a lightweight SPA for chatting with skills and reviewing conversation history
- extend configuration, docs, and examples with integration settings, local knowledge bases, and security guidance

## Testing
- `pip install -r requirements.txt`
- `python -m interfaces.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_68cd450c2d188321a056f20ee275243a