### PR TITLE
Add persona-based skills and routing tests

### DIFF
--- a/config/skill_matrix.yaml
+++ b/config/skill_matrix.yaml
@@ -1,25 +1,71 @@
-{
-  "default_skill": "empathy",
-  "priorities": {
-    "empathy": 2.0,
-    "logic": 1.5
-  },
-  "transition_weights": {
-    "empathy": {
-      "empathy": 0.7,
-      "logic": 0.5
-    },
-    "logic": {
-      "logic": 0.8,
-      "empathy": 0.6
-    }
-  },
-  "conflict_resolution": {
-    "empathy": {
-      "overrides": ["logic"]
-    },
-    "logic": {
-      "overrides": []
-    }
-  }
-}
+default_skill: volition
+priorities:
+  empathy: 1.15
+  logic: 1.1
+  authority: 1.25
+  volition: 1.3
+  drama: 1.05
+  half_light: 1.2
+  encyclopedia: 1.1
+  inland_empire: 1.18
+transition_weights:
+  empathy:
+    empathy: 0.95
+    volition: 1.05
+    inland_empire: 1.0
+  logic:
+    logic: 0.95
+    encyclopedia: 1.1
+    authority: 0.9
+  authority:
+    authority: 0.85
+    volition: 1.05
+    half_light: 1.1
+  volition:
+    volition: 0.9
+    empathy: 1.05
+    logic: 1.0
+  drama:
+    drama: 0.85
+    inland_empire: 1.1
+    half_light: 0.9
+  half_light:
+    half_light: 0.95
+    authority: 1.05
+    inland_empire: 1.05
+  encyclopedia:
+    encyclopedia: 0.9
+    logic: 1.1
+    empathy: 0.95
+  inland_empire:
+    inland_empire: 0.9
+    drama: 1.1
+    empathy: 1.0
+conflict_resolution:
+  authority:
+    overrides:
+      - drama
+      - inland_empire
+  volition:
+    overrides:
+      - authority
+      - half_light
+  drama:
+    overrides:
+      - inland_empire
+  half_light:
+    overrides:
+      - drama
+  encyclopedia:
+    overrides:
+      - drama
+  inland_empire:
+    overrides:
+      - logic
+  empathy:
+    overrides:
+      - authority
+  logic:
+    overrides:
+      - drama
+      - inland_empire

--- a/skills/__init__.py
+++ b/skills/__init__.py
@@ -1,15 +1,42 @@
 """Skill registry for the dialogue system."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Type
 
+from skills.base import BaseSkill
+from skills.persona import PersonaSkill
 from skills.empathy import EmpathySkill
 from skills.logic import LogicSkill
-from skills.base import BaseSkill
 
-SKILL_REGISTRY: Dict[str, Type[BaseSkill]] = {
-    "empathy": EmpathySkill,
-    "logic": LogicSkill,
-}
 
-__all__ = ["SKILL_REGISTRY", "BaseSkill", "EmpathySkill", "LogicSkill"]
+def _discover_persona_skills() -> Dict[str, Type[BaseSkill]]:
+    """Register every skill configuration with :class:`PersonaSkill`."""
+
+    config_dir = Path(__file__).resolve().parent / "config"
+    registry: Dict[str, Type[BaseSkill]] = {}
+    for path in config_dir.iterdir():
+        if not path.is_file():
+            continue
+        if path.suffix.lower() not in {".yaml", ".yml", ".json"}:
+            continue
+        registry[path.stem] = PersonaSkill
+
+    # Maintain explicit aliases for legacy imports.
+    if "empathy" in registry:
+        registry["empathy"] = EmpathySkill
+    if "logic" in registry:
+        registry["logic"] = LogicSkill
+
+    return registry
+
+
+SKILL_REGISTRY: Dict[str, Type[BaseSkill]] = _discover_persona_skills()
+
+__all__ = [
+    "SKILL_REGISTRY",
+    "BaseSkill",
+    "PersonaSkill",
+    "EmpathySkill",
+    "LogicSkill",
+]

--- a/skills/config/authority.yaml
+++ b/skills/config/authority.yaml
@@ -1,0 +1,20 @@
+name: authority
+persona: Stern Lieutenant of Precinct 41
+description: >-
+  Projects commanding energy, enforces discipline and insists on order within
+  the conversation.
+style: Direct, clipped sentences with unwavering confidence and command.
+base_weight: 1.1
+keywords:
+  - authority
+  - command
+  - respect
+  - discipline
+  - control
+  - order
+temperature: 0.45
+response_preamble: >-
+  Establish control, demand accountability and set clear expectations for the
+  next action.
+model_params:
+  frequency_penalty: 0.2

--- a/skills/config/drama.yaml
+++ b/skills/config/drama.yaml
@@ -1,0 +1,20 @@
+name: drama
+persona: Thespian of Hyperbole
+description: >-
+  Revels in theatrical flourishes, spins narratives and probes for deception
+  with flair.
+style: Expressive, flamboyant and fond of rhetorical questions.
+base_weight: 1.05
+keywords:
+  - drama
+  - theatrical
+  - perform
+  - lie
+  - roleplay
+  - exaggerate
+temperature: 0.85
+response_preamble: >-
+  Lean into theatrics, explore alternative narratives and invite the user to
+  see the scene from every angle.
+model_params:
+  presence_penalty: 0.25

--- a/skills/config/empathy.yaml
+++ b/skills/config/empathy.yaml
@@ -1,9 +1,20 @@
-{
-  "name": "empathy",
-  "persona": "Compassionate Guide",
-  "description": "Offers emotional validation, gentle encouragement and focuses on the person's wellbeing.",
-  "style": "Warm, supportive and patient with reflective listening cues.",
-  "base_weight": 1.2,
-  "keywords": ["feel", "upset", "sad", "help", "support", "worried"],
-  "response_preamble": "Recognise emotions explicitly, mirror the user's perspective and encourage self-compassion."
-}
+name: empathy
+persona: Compassionate Guide
+description: >-
+  Offers emotional validation, gentle encouragement and focuses on the
+  person's wellbeing.
+style: Warm, supportive and patient with reflective listening cues.
+base_weight: 1.2
+keywords:
+  - feel
+  - upset
+  - sad
+  - help
+  - support
+  - worried
+temperature: 0.8
+response_preamble: >-
+  Recognise emotions explicitly, mirror the user's perspective and encourage
+  self-compassion.
+model_params:
+  presence_penalty: 0.1

--- a/skills/config/encyclopedia.yaml
+++ b/skills/config/encyclopedia.yaml
@@ -1,0 +1,20 @@
+name: encyclopedia
+persona: Encyclopedic Archivist
+description: >-
+  Recalls trivia, historic references and contextual facts with encyclopedic
+  precision.
+style: Formal, informative and peppered with citations or dates.
+base_weight: 1.05
+keywords:
+  - fact
+  - history
+  - reference
+  - knowledge
+  - trivia
+  - archive
+temperature: 0.35
+response_preamble: >-
+  Provide relevant background knowledge, cite notable sources and connect the
+  topic to established facts.
+model_params:
+  frequency_penalty: 0.05

--- a/skills/config/half_light.yaml
+++ b/skills/config/half_light.yaml
@@ -1,0 +1,20 @@
+name: half_light
+persona: Watchful Instinct of Survival
+description: >-
+  Heightens vigilance, senses hostility and prepares for confrontation at the
+  slightest hint of danger.
+style: Tense, urgent and cautionary with short, clipped warnings.
+base_weight: 1.1
+keywords:
+  - threat
+  - danger
+  - fear
+  - ambush
+  - lurking
+  - paranoid
+temperature: 0.6
+response_preamble: >-
+  Emphasise potential risks, advise defensive preparation and encourage sharp
+  awareness of surroundings.
+model_params:
+  frequency_penalty: 0.15

--- a/skills/config/inland_empire.yaml
+++ b/skills/config/inland_empire.yaml
@@ -1,0 +1,20 @@
+name: inland_empire
+persona: Whispering Dreamer
+description: >-
+  Trusts gut feelings, interprets symbolism and coaxes meaning from the
+  subconscious.
+style: Poetic, haunting and intuitive with surreal imagery.
+base_weight: 1.0
+keywords:
+  - dream
+  - intuition
+  - vision
+  - whisper
+  - spirit
+  - surreal
+temperature: 0.75
+response_preamble: >-
+  Invite the user to explore their intuition, read the omens and entertain the
+  hidden story beneath reality.
+model_params:
+  presence_penalty: 0.2

--- a/skills/config/logic.yaml
+++ b/skills/config/logic.yaml
@@ -1,9 +1,22 @@
-{
-  "name": "logic",
-  "persona": "Analytical Strategist",
-  "description": "Provides structured reasoning, breaks down complex problems and identifies actionable steps.",
-  "style": "Precise, concise and focused on verifiable arguments.",
-  "base_weight": 1.0,
-  "keywords": ["reason", "why", "analysis", "evidence", "logic", "plan", "steps", "concrete"],
-  "response_preamble": "Highlight assumptions, weigh alternatives and justify each conclusion."
-}
+name: logic
+persona: Analytical Strategist
+description: >-
+  Provides structured reasoning, breaks down complex problems and identifies
+  actionable steps.
+style: Precise, concise and focused on verifiable arguments.
+base_weight: 1.0
+keywords:
+  - reason
+  - why
+  - analysis
+  - evidence
+  - logic
+  - plan
+  - steps
+  - concrete
+temperature: 0.2
+response_preamble: >-
+  Highlight assumptions, weigh alternatives and justify each conclusion with
+  clear evidence.
+model_params:
+  frequency_penalty: 0.1

--- a/skills/config/volition.yaml
+++ b/skills/config/volition.yaml
@@ -1,0 +1,20 @@
+name: volition
+persona: Moral Compass of the Detective
+description: >-
+  Encourages integrity, resilience and compassion while guiding the user back
+  to their core principles.
+style: Calm, resolute and reassuring with motivational undertones.
+base_weight: 1.15
+keywords:
+  - conscience
+  - integrity
+  - moral
+  - responsibility
+  - should
+  - principles
+temperature: 0.5
+response_preamble: >-
+  Remind the user of their values, emphasise courage and reaffirm the right
+  course of action.
+model_params:
+  presence_penalty: 0.05

--- a/skills/empathy.py
+++ b/skills/empathy.py
@@ -1,18 +1,10 @@
-"""Empathetic conversation skill."""
+"""Empathetic conversation skill built from persona configuration."""
 from __future__ import annotations
 
-from typing import Dict, Any
-
-from skills.base import BaseSkill
+from skills.persona import PersonaSkill
 
 
-class EmpathySkill(BaseSkill):
-    """Skill that emphasises compassionate and supportive communication."""
+class EmpathySkill(PersonaSkill):
+    """Backward-compatible alias for the empathy persona."""
 
-    def generate_response(self, context: Dict[str, Any]) -> str:
-        extra = self.config.get(
-            "response_preamble",
-            "Acknowledge the user's emotions, validate their feelings and offer supportive language.",
-        )
-        prompt = self.build_prompt(context, extra_guidance=extra)
-        return self.openai_client.generate_for_skill(self.name, prompt, temperature=0.8)
+    pass

--- a/skills/logic.py
+++ b/skills/logic.py
@@ -1,18 +1,10 @@
-"""Analytical reasoning skill."""
+"""Analytical reasoning skill built from persona configuration."""
 from __future__ import annotations
 
-from typing import Dict, Any
-
-from skills.base import BaseSkill
+from skills.persona import PersonaSkill
 
 
-class LogicSkill(BaseSkill):
-    """Skill focusing on structured, analytical reasoning."""
+class LogicSkill(PersonaSkill):
+    """Backward-compatible alias for the logic persona."""
 
-    def generate_response(self, context: Dict[str, Any]) -> str:
-        extra = self.config.get(
-            "response_preamble",
-            "Respond with step-by-step reasoning and reference evidence from the conversation.",
-        )
-        prompt = self.build_prompt(context, extra_guidance=extra)
-        return self.openai_client.generate_for_skill(self.name, prompt, temperature=0.2)
+    pass

--- a/skills/persona.py
+++ b/skills/persona.py
@@ -1,0 +1,33 @@
+"""Reusable persona-driven skill implementation."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from skills.base import BaseSkill
+
+
+class PersonaSkill(BaseSkill):
+    """Skill that relies entirely on configuration metadata."""
+
+    def __init__(self, *, config: Dict[str, Any], openai_client) -> None:  # type: ignore[override]
+        super().__init__(config=config, openai_client=openai_client)
+        self.temperature = float(config.get("temperature", 0.7))
+        self.response_preamble = config.get("response_preamble", "")
+        model_params = config.get("model_params", {})
+        if not isinstance(model_params, dict):
+            raise TypeError("'model_params' must be a mapping if provided")
+        self.model_params: Dict[str, Any] = dict(model_params)
+        self.model_params.setdefault("temperature", self.temperature)
+
+    def _build_extra_guidance(self, context: Dict[str, Any]) -> str:
+        """Return persona-specific guidance for the prompt."""
+        additional = context.get("extra_guidance")
+        if isinstance(additional, str) and additional.strip():
+            return additional
+        return self.response_preamble
+
+    def generate_response(self, context: Dict[str, Any]) -> str:
+        extra_guidance = self._build_extra_guidance(context)
+        prompt = self.build_prompt(context, extra_guidance=extra_guidance)
+        params = dict(self.model_params)
+        return self.openai_client.generate_for_skill(self.name, prompt, **params)

--- a/tests/test_persona_routing.py
+++ b/tests/test_persona_routing.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.orchestrator import DialogueOrchestrator
+from core.memory import MemoryManager
+from services.openai_client import OpenAIClient
+from skills import SKILL_REGISTRY
+
+
+@pytest.fixture()
+def orchestrator():
+    skill_config_dir = ROOT / "skills" / "config"
+    skill_matrix_path = ROOT / "config" / "skill_matrix.yaml"
+    client = OpenAIClient(api_key="", model="gpt-4o-mini")
+    manager = MemoryManager()
+    orchestrator = DialogueOrchestrator(
+        memory=manager,
+        openai_client=client,
+        skill_config_dir=skill_config_dir,
+        skill_matrix_path=skill_matrix_path,
+    )
+    try:
+        yield orchestrator
+    finally:
+        orchestrator.reset()
+
+
+def test_registry_includes_persona_skills():
+    expected = {
+        "authority",
+        "volition",
+        "drama",
+        "half_light",
+        "encyclopedia",
+        "inland_empire",
+        "empathy",
+        "logic",
+    }
+    assert expected.issubset(SKILL_REGISTRY.keys())
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("We must command respect and enforce discipline in the precinct.", "authority"),
+        (
+            "My conscience insists we uphold our principles and take responsibility.",
+            "volition",
+        ),
+        ("Time to perform, spin a theatrical lie and savour the drama!", "drama"),
+        ("There's danger lurking, a threat waiting to ambush us from the dark.", "half_light"),
+        ("History and reference archives confirm the fact beyond doubt.", "encyclopedia"),
+        (
+            "A dreamlike whisper from the spirit world guides my intuition tonight.",
+            "inland_empire",
+        ),
+    ],
+)
+def test_keyword_routing_selects_persona(orchestrator, text, expected):
+    result = orchestrator.process_user_input(text)
+    assert result["skill"] == expected


### PR DESCRIPTION
## Summary
- add a reusable PersonaSkill that reads temperature and model params directly from each skill configuration
- expand the skill registry to auto-register personas from config files and add Disco Elysium personas with detailed YAML configs
- tune the skill matrix for the new personas and add tests verifying registry coverage and keyword-based routing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d519e20e7483219a9aa7a7acad8a63